### PR TITLE
Privacy: gate analytics + comments behind consent, remove FB Pixel

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -319,6 +319,7 @@ CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
+  bundler (4.0.12) sha256=7f8b757d28dfb636e7b24fba2344ac6dd13b5b24f4b46d62573d483f211825ac
   coffee-script (2.4.1) sha256=82fe281e11b93c8117b98c5ea8063e71741870f1c4fbb27177d7d6333dd38765
   coffee-script-source (1.12.2) sha256=e12b16fd8927fbbf8b87cb2e9a85a6cf457c6881cc7ff8b1af15b31f70da07a4
   colorator (1.1.0) sha256=e2f85daf57af47d740db2a32191d1bdfb0f6503a0dfbc8327d0c9154d5ddfc38
@@ -428,4 +429,4 @@ CHECKSUMS
   webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
 
 BUNDLED WITH
-  4.0.9
+  4.0.12

--- a/_includes/cookie-consent.html
+++ b/_includes/cookie-consent.html
@@ -1,0 +1,85 @@
+<style>
+  .cookie-banner {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 9999;
+    background: #222;
+    color: #fff;
+    padding: 1em 1.25em;
+    font-size: 0.9em;
+    line-height: 1.4;
+    box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.15);
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1em;
+  }
+  .cookie-banner[hidden] { display: none; }
+  .cookie-banner p { margin: 0; flex: 1 1 320px; }
+  .cookie-banner a { color: #fff; text-decoration: underline; }
+  .cookie-banner__buttons { display: flex; gap: 0.5em; flex-shrink: 0; }
+  .cookie-banner button {
+    border: 1px solid #fff;
+    background: transparent;
+    color: #fff;
+    padding: 0.4em 1em;
+    cursor: pointer;
+    font: inherit;
+    border-radius: 3px;
+  }
+  .cookie-banner button.is-primary { background: #fff; color: #222; }
+  .cookie-banner button:hover { opacity: 0.85; }
+</style>
+
+<div id="cookie-banner" class="cookie-banner" hidden>
+  <p>
+    This site uses cookies for analytics and to power the comments section.
+    See our <a href="{{ '/privacy-policy/' | prepend: site.baseurl }}">privacy policy</a>.
+  </p>
+  <div class="cookie-banner__buttons">
+    <button type="button" id="cookie-decline">Decline</button>
+    <button type="button" id="cookie-accept" class="is-primary">Accept</button>
+  </div>
+</div>
+
+<script>
+(function() {
+  var KEY = 'drinkbird-consent';
+  var banner = document.getElementById('cookie-banner');
+
+  function grantConsent() {
+    document.dispatchEvent(new CustomEvent('drinkbird:consent-granted'));
+  }
+
+  function hideBanner() { if (banner) banner.hidden = true; }
+  function showBanner() { if (banner) banner.hidden = false; }
+
+  document.getElementById('cookie-accept').addEventListener('click', function() {
+    try { localStorage.setItem(KEY, 'accepted'); } catch (e) {}
+    hideBanner();
+    grantConsent();
+  });
+
+  document.getElementById('cookie-decline').addEventListener('click', function() {
+    try { localStorage.setItem(KEY, 'declined'); } catch (e) {}
+    hideBanner();
+  });
+
+  var stored = null;
+  try { stored = localStorage.getItem(KEY); } catch (e) {}
+
+  if (stored === 'accepted') {
+    setTimeout(grantConsent, 0);
+  } else if (stored === null) {
+    showBanner();
+  }
+
+  window.drinkbirdResetConsent = function() {
+    try { localStorage.removeItem(KEY); } catch (e) {}
+    showBanner();
+  };
+})();
+</script>

--- a/_includes/disqus-comments.html
+++ b/_includes/disqus-comments.html
@@ -1,25 +1,30 @@
 {% if site.owner.disqus-shortname %}
+<div id="disqus_thread"></div>
 <script type="text/javascript">
+(function() {
+  function loadDisqus() {
     var disqus_shortname = '{{ site.owner.disqus-shortname }}';
 
-    var disqus_config = function () {
-        this.page.url = '{{ site.url }}{{ site.baseurl }}{{ page.url }}';
-        this.page.identifier = '{{ page.permalink }}';
-        this.page.title = '{{ page.title }} - {{ site.title }}';
+    window.disqus_config = function () {
+      this.page.url = '{{ site.url }}{{ site.baseurl }}{{ page.url }}';
+      this.page.identifier = '{{ page.permalink }}';
+      this.page.title = '{{ page.title }} - {{ site.title }}';
     };
 
-    (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-    })();
+    var dsq = document.createElement('script');
+    dsq.type = 'text/javascript';
+    dsq.async = true;
+    dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
+    (document.head || document.body).appendChild(dsq);
 
-    (function () {
-        var s = document.createElement('script'); s.async = true;
-        s.type = 'text/javascript';
-        s.src = '//' + disqus_shortname + '.disqus.com/count.js';
-        (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
-    }());
+    var count = document.createElement('script');
+    count.type = 'text/javascript';
+    count.async = true;
+    count.src = 'https://' + disqus_shortname + '.disqus.com/count.js';
+    (document.head || document.body).appendChild(count);
+  }
+  document.addEventListener('drinkbird:consent-granted', loadDisqus, { once: true });
+})();
 </script>
 <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
 {% endif %}

--- a/_includes/google-analytics.html
+++ b/_includes/google-analytics.html
@@ -1,9 +1,16 @@
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-1P3RKC5DS0"></script>
 <script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
+(function() {
+  function loadGA() {
+    var s = document.createElement('script');
+    s.async = true;
+    s.src = 'https://www.googletagmanager.com/gtag/js?id={{ site.owner.google.analytics }}';
+    document.head.appendChild(s);
 
-  gtag('config', 'G-1P3RKC5DS0');
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){ dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', '{{ site.owner.google.analytics }}');
+  }
+  document.addEventListener('drinkbird:consent-granted', loadGA, { once: true });
+})();
 </script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,15 +12,6 @@
 <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ site.baseurl }}/feed.xml" />
 <meta name="author" content="Tasos Piotopoulos (Anastasios)" />
 <meta name="copyright" content="Tasos Piotopoulos (Anastasios)" />
-<script>
-!function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
-n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
-t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
-document,'script','//connect.facebook.net/en_US/fbevents.js');
-fbq('init', '1080575201987276');
-fbq('track', "PageView");</script>
-<noscript><img height="1" width="1" style="display:none"src="https://www.facebook.com/tr?id=1080575201987276&ev=PageView&noscript=1"/></noscript>
 
 {% if site.owner.google.analytics %}
 {% include google-analytics.html %}

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -7,11 +7,7 @@
 <script src="{{ site.baseurl }}/assets/js/jquery.waypoints.min.js"></script>
 <script src="{{ site.baseurl }}/assets/js/scripts.min.js"></script>
 
-<script type="text/javascript">
-    window.cookieconsent_options = {"message":"This website uses cookies to ensure you get the best experience possible","dismiss":"Got it","learnMore":"More info","link":"https://blog.drinkbird.com/privacy-policy","theme":"light-bottom"};
-</script>
-
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/1.0.9/cookieconsent.min.js"></script>
+{% include cookie-consent.html %}
 
 <!--
 <script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='SOURCE';ftypes[1]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>

--- a/privacy.md
+++ b/privacy.md
@@ -4,52 +4,49 @@ title: Privacy Policy and Disclosure for DrinkBird
 permalink: /privacy-policy/
 ---
 
-If you require any more information or have any questions about our privacy policy, please feel free to contact us by email at [tasos [at] drinkbird.com](&#109;&#97;&#105;&#108;&#116;&#111;:&#116;&#97;&#115;&#111;&#115;&#64;&#100;&#114;&#105;&#110;&#107;&#98;&#105;&#114;&#100;&#46;&#99;&#111;&#109;).
+This page explains, in plain language, what data this site collects, why, and what your rights are. Questions go to [tasos [at] drinkbird.com](&#109;&#97;&#105;&#108;&#116;&#111;:&#116;&#97;&#115;&#111;&#115;&#64;&#100;&#114;&#105;&#110;&#107;&#98;&#105;&#114;&#100;&#46;&#99;&#111;&#109;).
 
-At drinkbird.com we consider the privacy of our visitors to be extremely important. This privacy policy document describes in detail the types of personal information is collected and recorded by drinkbird.com and how we process and use it.
+# What we collect
 
-# Log Files
+DrinkBird is a static personal blog. We collect as little as possible.
 
-Like many other Web sites, drinkbird.com makes use of log files. These files merely logs visitors to the site - usually a standard procedure for hosting companies and a part of hosting services's analytics. The information inside the log files includes internet protocol (IP) addresses, browser type, Internet Service Provider (ISP), date/time stamp, referring/exit pages, and possibly the number of clicks. This information is used to analyze trends, administer the site, track user's movement around the site, and gather demographic information. IP addresses, and other such information are not linked to any information that is personally identifiable.
+- **Server logs.** The hosting provider (GitHub Pages) keeps standard access logs containing IP address, browser type, referrer, and timestamp. These are used by the host to operate the service and detect abuse. We do not access or analyse them ourselves.
+- **Analytics (with your consent).** If you accept analytics cookies via the consent banner, the site loads Google Analytics 4. GA4 records page views and aggregate usage. IP addresses are truncated by Google before storage. No analytics scripts load until you accept.
+- **Comments (with your consent).** If you accept and choose to comment via Disqus, Disqus collects whatever you provide (name/email, comment text) plus their own usage data. The Disqus scripts do not load until you accept. See the [Disqus Privacy Policy](https://help.disqus.com/customer/en/portal/articles/466259-privacy-policy).
 
-# Cookies and Web Beacons
+We do **not** run advertising trackers, retargeting pixels, or marketing email lists on this site.
 
-drinkbird.com uses cookies to store information about visitors' preferences, to record user-specific information on which pages the site visitor accesses or visits, and to personalize or customize our web page content based upon visitors' browser type or other information that the visitor sends via their browser.
+# Cookies and consent
 
-# Disclosure
- 
-As an Amazon Associate I earn from qualifying purchases.
+On your first visit you'll see a banner asking whether to accept cookies for analytics and comments. Your choice is stored locally in your browser (`localStorage`) and remembered for future visits. You can change your mind at any time by clearing site data in your browser.
 
-# Third Party Privacy Policies
+If you decline, no analytics or Disqus scripts load. If you accept, those scripts load and may set their own cookies — see the third-party policies above for details.
 
-You should consult the respective privacy policies of these third-party ad servers for more detailed information on their practices as well as for instructions about how to opt-out of certain practices. drinkbird.com's privacy policy does not apply to, and we cannot control the activities of, such other advertisers or web sites.
+# Your rights
 
-You may find a comprehensive listing of these privacy policies and their links here: [Privacy Policy Links](http://www.privacypolicyonline.com/privacy-policies/).
+If you're in the EU/EEA, UK, or California, you have specific rights over your personal data:
 
-If you wish to disable cookies, you may do so through your individual browser options. More detailed information about cookie management with specific web browsers can be found at the browsers' respective websites. [What Are Cookies?](http://www.privacypolicyonline.com/what-are-cookies)
+- Access — find out what data we hold about you (in practice: very little, since we don't keep our own database).
+- Deletion — ask us to remove what we have.
+- Objection — tell us to stop processing your data.
+- Portability — get a copy in a usable format.
 
-- Google Analytics: *This website uses Google Analytics, a web analytics service provided by Google, Inc. ("Google"). Google Analytics uses "cookies", which are text files placed on your computer to help the website analyse how visitors use the site. The information generated by the cookie about your use of the website (including your IP address) will be transmitted to and stored by Google on servers in the United States. Google will use this information for the purpose of evaluating your use of the website, compiling reports on website activity for website operators and providing other services relating to website activity and internet usage. Google may also transfer this information to third parties where required to do so by law, or where such third parties process the information on Google's behalf. Google will not associate your IP address with any other data held by Google. You may refuse the use of cookies by selecting the appropriate settings on your browser, however please note that if you do this you may not be able to use the full functionality of this website. By using this website, you consent to the processing of data about you by Google in the manner and for the purposes set out above.* You can also view the latest version of [Google Privacy Policy](https://policies.google.com/privacy?hl=en)
-- Facebook Pixel: *This website uses Facebook Pixel, a statistics tool by Facebook that helps measuring the effectiveness of advertisements.* [Facebook Privacy Policy](https://www.facebook.com/about/privacy/)
-- Disqus: *This website uses Disqus to provide the users the ability to submit comments.* [Disqus Privacy Policy](https://help.disqus.com/customer/en/portal/articles/466259-privacy-policy)
-- Mailchimp: *This website uses Mailchimp to send out communication and marketing to users that have opted in.* [Mailchimp Privacy Policy](https://mailchimp.com/legal/privacy/)
+Email the address above to exercise any of these. We will respond within 30 days.
 
-# Children's Information
+For data held by Google (analytics) or Disqus (comments), contact them directly using the links above — we can only delete what's in our control.
 
-We believe it is important to provide added protection for children online. We encourage parents and guardians to spend time online with their children to observe, participate in and/or monitor and guide their online activity.
+# Children
 
-drinkbird.com does not knowingly collect any personally identifiable information from children under the age of 13. If a parent or guardian believes that drinkbird.com has in its database the personally-identifiable information of a child under the age of 13, please contact us immediately (using the contact in the first paragraph) and we will use our best efforts to promptly remove such information from our records.
+DrinkBird is aimed at adults and does not knowingly collect data from children under 13 (or 16 in the EU). If you believe a child has submitted personal data through this site, email us and we will remove it.
 
-# Online Privacy Policy Only
+# Amazon Associates disclosure
 
-This privacy policy applies only to our online activities and is valid for visitors to our website and regarding information shared and/or collected there.
-This policy does not apply to any information collected offline or via channels other than this website.
+DrinkBird participates in the Amazon Associates Program. Some links to books and products on this site are affiliate links, which means we may earn a small commission if you click through and make a purchase. This does not change the price you pay. The recommendations are based on what we genuinely think is worth reading.
 
-# Consent
+# Changes to this policy
 
-By using our website, you hereby consent to our privacy policy and agree to its terms.
+Material changes will be posted on this page with an updated date. Continued use of the site after changes constitutes acceptance.
 
 # Update
 
-This Privacy Policy was last updated on: Tuesday, May 24th, 2018.
-
-*Should we update, amend or make any changes to our privacy policy, those changes will be posted here.*
+This Privacy Policy was last updated on: 2026-05-24.


### PR DESCRIPTION
## Summary

- **Removed Facebook Pixel** from `_includes/head.html` — was firing on every page load with no consent gate since ~2017; no active campaign needs it.
- **Added a real consent gate**: new `_includes/cookie-consent.html` is a small vanilla-JS banner that stores the visitor's choice in `localStorage` and dispatches a `drinkbird:consent-granted` custom event when accepted.
- **GA4 and Disqus now actually wait for consent** — both includes listen for the event and only inject their scripts after acceptance. Previously the cookieconsent2 library was decorative; trackers fired regardless of the banner.
- **Rewrote `privacy.md`** for 2026 — plain language, GDPR + CCPA rights, accurate tracker list (removed Mailchimp/FB Pixel references), kept the Amazon Associates disclosure.
- Cleaned up two small things on the way past: switched the hardcoded GA4 ID to read from `_config.yml` (`site.owner.google.analytics`), and bumped Disqus URLs from protocol-relative to `https://`.

Closes #28.

## Test plan

- [ ] `bundle exec jekyll serve --livereload` — open in a fresh incognito window.
- [ ] Cookie banner appears at the bottom of every page.
- [ ] Open DevTools Network tab → click **Decline** → banner disappears; **no** requests to `googletagmanager.com` or `disqus.com`.
- [ ] Reload — banner stays hidden, still no tracker requests.
- [ ] `localStorage.clear()` in the console + reload → banner returns. Click **Accept** → requests to `googletagmanager.com` (and Disqus on a post page) fire.
- [ ] Quick `drinkbirdResetConsent()` in the console also re-shows the banner without clearing other site data.
- [ ] `privacy.md` renders correctly at `/privacy-policy/` and links from the banner work.

## Deliberately out of scope (let me know if you want any of these now)

- A "Cookie settings" link in the footer to call `drinkbirdResetConsent()` — small UX win.
- Moving the banner CSS from inline `<style>` into `_sass/` partials — inline keeps the include self-contained and easy to remove later.