### PR TITLE
Cache-bust local CSS/JS assets via per-build query string

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,8 +4,8 @@
 <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.longdescription }}{% endif %}">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css">
-<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/glightbox.min.css">
+<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css?v={{ site.time | date: '%s' }}">
+<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/glightbox.min.css?v={{ site.time | date: '%s' }}">
 <script defer src="https://kit.fontawesome.com/3e89c5fbcc.js"></script>
 
 <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,10 +1,10 @@
 <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha384-1H217gwSVyLSIfaLxHbE7dRb3v4mYCKbpQvzx0cegeju1MVsGrX5xXxAvs/HgeFs" crossorigin="anonymous"></script>
-<script>window.jQuery || document.write('<script src="{{ site.baseurl }}/assets/js/jquery-3.7.1.min.js"><\/script>')</script>
-<script src="{{ site.baseurl }}/assets/js/bootstrap.min.js"></script>
-<script src="{{ site.baseurl }}/assets/js/jquery.fitvids.js"></script>
-<script src="{{ site.baseurl }}/assets/js/jquery.sticky.js"></script>
-<script src="{{ site.baseurl }}/assets/js/glightbox.min.js"></script>
-<script src="{{ site.baseurl }}/assets/js/scripts.min.js"></script>
+<script>window.jQuery || document.write('<script src="{{ site.baseurl }}/assets/js/jquery-3.7.1.min.js?v={{ site.time | date: '%s' }}"><\/script>')</script>
+<script src="{{ site.baseurl }}/assets/js/bootstrap.min.js?v={{ site.time | date: '%s' }}"></script>
+<script src="{{ site.baseurl }}/assets/js/jquery.fitvids.js?v={{ site.time | date: '%s' }}"></script>
+<script src="{{ site.baseurl }}/assets/js/jquery.sticky.js?v={{ site.time | date: '%s' }}"></script>
+<script src="{{ site.baseurl }}/assets/js/glightbox.min.js?v={{ site.time | date: '%s' }}"></script>
+<script src="{{ site.baseurl }}/assets/js/scripts.min.js?v={{ site.time | date: '%s' }}"></script>
 
 {% include cookie-consent.html %}
 
@@ -18,7 +18,7 @@
         return elem.getScreenCTM().inverse().multiply(this.getScreenCTM());
     };
 </script>
-<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/mermaid.css">
-<script src="{{ site.baseurl }}/assets/js/mermaid.min.js"></script>
+<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/mermaid.css?v={{ site.time | date: '%s' }}">
+<script src="{{ site.baseurl }}/assets/js/mermaid.min.js?v={{ site.time | date: '%s' }}"></script>
 <script>mermaid.initialize({startOnLoad:true});</script>
 {% endif %}


### PR DESCRIPTION
## Summary

Triggered by the post-#38 incident: readers with cached `scripts.min.js` (still referencing magnificPopup) saw `$(...).magnificPopup is not a function` on the live site until a hard reload. Browsers had no signal to refetch — same URL, different bytes.

Fix: append `?v={{ site.time | date: '%s' }}` to every local `<link href>` and `<script src>` in `_includes/head.html` and `_includes/scripts.html`. The URL shifts on each build (Jekyll's `site.time` updates per `jekyll build`), so any content change invalidates browser caches automatically on the next deploy.

## Cache-busted

- `assets/css/main.css`
- `assets/css/glightbox.min.css`
- `assets/css/mermaid.css` *(conditional on `page.mermaid`)*
- `assets/js/jquery-3.7.1.min.js` *(local fallback when CDN fails)*
- `assets/js/bootstrap.min.js`
- `assets/js/jquery.fitvids.js`
- `assets/js/jquery.sticky.js`
- `assets/js/glightbox.min.js`
- `assets/js/scripts.min.js`
- `assets/js/mermaid.min.js` *(conditional)*

## Intentionally not cache-busted

- The jQuery CDN URL (`code.jquery.com/jquery-3.7.1.min.js`) — version is already in the path; immutable.
- Book-cover images and other Amazon CDN-hosted assets.
- Auto-generated `feed.xml` / `sitemap.xml`.

## Trade-offs

- Coarse-grained: every push invalidates *every* asset, even ones that didn't change. Acceptable for a low-traffic personal blog; the alternative (per-file fingerprinting) needs build tooling we don't have.
- `site.time` is set at build time, so during local dev every regenerate gives new URLs — actually a small win for the dev loop (you always see the latest CSS/JS without manual hard-reload).

Closes #39.

## Test plan

- [ ] `bundle exec jekyll serve`, view source on homepage — every local `<script>`/`<link>` has `?v=<unix-timestamp>` appended.
- [ ] Open a mermaid post (e.g. `/psychological-safety/`) — `mermaid.css` and `mermaid.min.js` also carry the `?v=…`.
- [ ] After the merge ships, repeat the original symptom on the live site: change any local JS, push, hard-reload not needed — the URL changed.