### PR TITLE
Lazy-load below-the-fold feature images on listings

### DIFF
--- a/_includes/image-feature-list.html
+++ b/_includes/image-feature-list.html
@@ -5,6 +5,6 @@
       {% capture imageSource %}{{ site.baseurl }}/images/{{ post.image.feature }}{% endcapture %}
   {% endif %}  
   <figure>
-    <img src="{{ imageSource }}" alt="{{ post.title }} feature image" class="img-responsive">
+    <img src="{{ imageSource }}" alt="{{ post.title }} feature image" class="img-responsive" width="710" height="360" loading="{{ include.loading | default: 'lazy' }}" decoding="async">
   </figure>
 {% endif %}

--- a/posts.html
+++ b/posts.html
@@ -27,7 +27,8 @@ excerpt: "Distilled thoughts from the tech industry and literature"
       <div class="col-md-6">
         <article class="article-list">
           <a href="{{ site.baseurl }}{{ post.url }}" title="{{ post.title }}">
-            {% include image-feature-list.html %}
+            {% if count <= 2 %}{% assign loadingMode = 'eager' %}{% else %}{% assign loadingMode = 'lazy' %}{% endif %}
+            {% include image-feature-list.html loading=loadingMode %}
             <h1>{{ post.title }}</h1>
           </a>
           {% comment %}

--- a/projects.html
+++ b/projects.html
@@ -28,7 +28,8 @@ excerpt: "Some of the projects I've been involved with throughout my career"
       <div class="col-md-6">
         <article class="article-list">
           <a href="{{ site.baseurl }}{{ post.url }}" title="{{ post.title }}">
-            {% include image-feature-list.html %}
+            {% if count <= 2 %}{% assign loadingMode = 'eager' %}{% else %}{% assign loadingMode = 'lazy' %}{% endif %}
+            {% include image-feature-list.html loading=loadingMode %}
             <h1>{{ post.title }}</h1>
           </a>
           {% comment %}<time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %d, %Y" }}</time>{% endcomment %}


### PR DESCRIPTION
## Summary
- Add `loading="lazy"` and `decoding="async"` to the feature-image `<figure>` include, defaulting to lazy via an `include.loading` param.
- Mark the first two thumbnails on `/posts/` and `/projects/` as `loading="eager"` so above-the-fold paint is unaffected.
- Set explicit `width="710" height="360"` so the browser reserves layout space immediately — removes the top-down repaint where `/posts/` fetched all 44 thumbnails in parallel and painted them as bytes arrived.

Home page featured stories keep the lazy default since they sit below the jumbotron hero.

## Test plan
- [x] `bundle exec jekyll build` completes clean
- [x] Inspected rendered HTML: `/posts/` first 2 imgs are `loading="eager"`, remaining 42 are `loading="lazy"`; same split on `/projects/`; home page featured imgs are `lazy`
- [x] Smoke-test in browser: load `/posts/`, confirm no top-down shuffle and that off-screen thumbnails only fetch as they approach the viewport (DevTools Network tab)